### PR TITLE
fix: запуск ci только на создание тега

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,9 +2,8 @@ name: Android CI
 
 on:
   push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+    tags:
+      - '**'
 
 jobs:
   build:


### PR DESCRIPTION
предлагаю запускать ci только на создание тега, в будущем стоит рассмотреть использование общего шаблона для релизных тегов, например v\*.\*.\*